### PR TITLE
fix(exceptions): log message after requests.raise_for_status()

### DIFF
--- a/parcel/download_stream.py
+++ b/parcel/download_stream.py
@@ -125,7 +125,11 @@ class DownloadStream(object):
                 "Unable to connect to API: ({}). Is this url correct: '{}'? "
                 "Is there a connection to the API? Is the server running?"
             ).format(str(e), self.uri))
-        r.raise_for_status()
+        try:
+            r.raise_for_status()
+        except Exception as e:
+            raise RuntimeError('{}: {}'.format(str(e), r.text))
+
         if close:
             r.close()
         return r


### PR DESCRIPTION
- raise_for_status doesn't return the content of the response when
  raising an exception.
- Wrap this call to log response.text as well to exception message.