### PR TITLE
fix(logging): s/stdout/stderr/g

### DIFF
--- a/parcel/log.py
+++ b/parcel/log.py
@@ -15,13 +15,13 @@ def get_logger(name='parcel'):
         return loggers[name]
     log = logging.getLogger(name)
     log.propagate = False
-    if sys.stdout.isatty():
+    if sys.stderr.isatty():
         formatter = logging.Formatter(
             colored('%(asctime)s: %(levelname)s: ', 'blue')+'%(message)s')
     else:
         formatter = logging.Formatter(
             '%(asctime)s: %(levelname)s: %(message)s')
-    handler = logging.StreamHandler(sys.stdout)
+    handler = logging.StreamHandler(sys.stderr)
     handler.setFormatter(formatter)
     log.addHandler(handler)
     loggers[name] = log


### PR DESCRIPTION
This just replaces `stdout` with `stderr` as the default logging file handle.

@millerjs r?