### PR TITLE
fix(download): break loop if exception raised

### DIFF
--- a/parcel/client.py
+++ b/parcel/client.py
@@ -198,6 +198,7 @@ class Client(object):
                         raise
                     else:
                         log.error("Download aborted: {}".format(str(e)))
+                        break
 
         # Divide work amongst process pool
         pool = [Process(target=download_worker) for i in range(n_procs)]


### PR DESCRIPTION
This fixes https://github.com/NCI-GDC/gdc-client/issues/12 - basically just stops the thread's loop when something breaks.

@millerjs r?