### PR TITLE
fix(download): recreate segments on retry

### DIFF
--- a/parcel/download_stream.py
+++ b/parcel/download_stream.py
@@ -186,7 +186,6 @@ class DownloadStream(object):
                 if not chunk:
                     continue  # Empty are keep-alives.
                 offset = start + written
-                written += len(chunk)
 
                 # Write the chunk to disk, create an interval that
                 # represents the chunk, get md5 info if necessary, and
@@ -198,6 +197,8 @@ class DownloadStream(object):
                     iv_data = None
                 complete_segment = Interval(offset, offset+len(chunk), iv_data)
                 q_complete.put(complete_segment)
+
+                written += len(chunk)
 
         except KeyboardInterrupt:
             return self.log.error('Process stopped by user.')

--- a/parcel/download_stream.py
+++ b/parcel/download_stream.py
@@ -204,6 +204,9 @@ class DownloadStream(object):
 
         # Retry on exception if we haven't exceeded max retries
         except Exception as e:
+            # TODO FIXME HACK create new segment to avoid duplicate downloads
+            segment = Interval(segment.begin+written, segment.end, None)
+
             self.log.debug(
                 'Unable to download part of file: {}\n.'.format(str(e)))
             if retries > 0:
@@ -215,6 +218,9 @@ class DownloadStream(object):
 
         # Check that the data is not truncated or elongated
         if written != segment.end-segment.begin:
+            # TODO FIXME HACK create new segment to avoid duplicate downloads
+            segment = Interval(segment.begin+written, segment.end, None)
+
             self.log.debug('Segment corruption: {}'.format(
                 '(non-fatal) retrying' if retries else 'max retries exceeded'))
             if retries:


### PR DESCRIPTION
Creates new segments before retry in order to avoid duplicate downloads. I think this will fix the reporting issue w/ progressbar since we'll only download each byte once.

@msfitzsimons
@allisonheath 
@millerjs r?