### PR TITLE
feat(dtt-29): no content-length, url not fileID

### DIFF
--- a/bin/parcel
+++ b/bin/parcel
@@ -10,6 +10,7 @@ from parcel import (
 import argparse
 import logging
 
+
 logging.root.setLevel(logging.INFO)
 log = logging.getLogger('parcel_client')
 
@@ -27,18 +28,16 @@ def get_client(args, token, **_kwargs):
     )
 
     if args.udt:
-        server = args.server or defaults.udt_url
         return UDTClient(
             proxy_host=args.proxy_host,
             proxy_port=args.proxy_port,
-            remote_uri=server,
+            verify=not args.no_verify,
             external_proxy=args.external_proxy,
             **kwargs
         )
     else:
-        server = args.server or defaults.tcp_url
         return HTTPClient(
-            uri=server,
+            verify=not args.no_verify,
             **kwargs
         )
 
@@ -50,14 +49,13 @@ def run_non_interactive(parser):
         return
 
     client = get_client(args, args.token)
+    logging.basicConfig()
 
     if args.verbose:
         logging.root.setLevel(logging.DEBUG)
 
     # Create file list and remove duplicates
-    file_ids = set([f['id'] for f in args.manifest] + args.file_ids)
-    log.info(version_string.replace('\n', ' - '))
-    client.download_files(file_ids)
+    client.download_files(args.urls)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
@@ -79,11 +77,8 @@ if __name__ == '__main__':
                         default=None,
                         help='Directory to download files to. '
                         'Defaults to current dir')
-    parser.add_argument('-s', '--server', metavar='server', type=str,
-                        default=None,
-                        help='The parcel server udt address server[:port]')
-    parser.add_argument('file_ids', metavar='file_id', type=str,
-                        nargs='*', help='uuids to download')
+    parser.add_argument('urls', metavar='urls', type=str,
+                        nargs='*', help='urls to download')
     parser.add_argument('--no-segment-md5sums', dest='segment_md5sums',
                         action='store_false',
                         help="Don't calculate inbound segment md5sums and/or verify md5sums on restart")
@@ -93,6 +88,8 @@ if __name__ == '__main__':
     parser.add_argument('--debug', dest='debug',
                         action='store_true',
                         help='Print stack traces')
+    parser.add_argument('--no-verify', dest='no_verify', action='store_true',
+                        help='Perform insecure SSL connection and transfer')
     parser.add_argument('-n', '--n-processes', type=int,
                         default=defaults.processes,
                         help='Number of client connections.')

--- a/parcel/http_client.py
+++ b/parcel/http_client.py
@@ -3,5 +3,5 @@ from .client import Client
 
 class HTTPClient(Client):
 
-    def __init__(self, uri, *args, **kwargs):
-        super(HTTPClient, self).__init__(uri, *args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super(HTTPClient, self).__init__(*args, **kwargs)

--- a/parcel/segment.py
+++ b/parcel/segment.py
@@ -46,7 +46,7 @@ class SegmentProducer(object):
 
     def _setup_pbar(self):
         self.pbar = None
-        self.pbar = get_pbar(self.download.ID, self.download.size)
+        self.pbar = get_pbar(self.download.url, self.download.size)
 
     def _setup_work(self):
         if self.is_complete():
@@ -73,7 +73,7 @@ class SegmentProducer(object):
             return True
         corrupt_segments = 0
         intervals = sorted(self.completed.items())
-        log.info('Checksumming {}:'.format(self.download.ID))
+        log.info('Checksumming {}:'.format(self.download.url))
         pbar = ProgressBar(widgets=[
             Percentage(), ' ',
             Bar(marker='#', left='[', right=']'), ' ', ETA()], fd=sys.stdout)
@@ -130,7 +130,7 @@ class SegmentProducer(object):
             log.warn(STRIP(
                 """State file found at '{}' but no file for {}.
                 Restarting entire download.""".format(
-                    self.download.state_path, self.download.ID)))
+                    self.download.state_path, self.download.url)))
             return
         try:
             with open(self.download.state_path, "rb") as f:

--- a/parcel/udt_client.py
+++ b/parcel/udt_client.py
@@ -10,16 +10,13 @@ log = logging.getLogger('client')
 
 class UDTClient(Client):
 
-    def __init__(self, proxy_host, proxy_port, remote_uri,
+    def __init__(self, proxy_host, proxy_port, verify=True,
                  external_proxy=False, *args, **kwargs):
-        if not remote_uri.startswith('http'):
-            remote_uri = 'https://{}'.format(remote_uri)
         if not external_proxy:
             # Create a local UDT proxy that translates TCP to UDT
             self.start_proxy_server(proxy_host, proxy_port, remote_uri)
-        local_uri = self.construct_local_uri(
-            proxy_host, proxy_port, remote_uri)
-        super(UDTClient, self).__init__(local_uri, *args, **kwargs)
+
+        super(UDTClient, self).__init__(*args, **kwargs)
 
     def construct_local_uri(self, proxy_host, proxy_port, remote_uri):
         """Given proxy settings and remote_uri, construct the uri where the

--- a/parcel/utils.py
+++ b/parcel/utils.py
@@ -57,7 +57,6 @@ def print_closing_header(file_id):
     log.debug('^{}^'.format('{s:{c}^{n}}'.format(
         s=' {} '.format(file_id), n=50, c='-')))
 
-
 def write_offset(path, data, offset):
     try:
         f = open(path, 'r+b')

--- a/test/test_parcel_http.py
+++ b/test/test_parcel_http.py
@@ -47,8 +47,7 @@ class TestParcelHTTP(unittest.TestCase):
                 ['parcel', '-v',
                  '-n1',
                  '-d', self.dest_dir,
-                 '-s', 'http://{}:{}'.format(server_host, server_port),
-                 file_id])
+                 'http://{}:{}/{}'.format(server_host, server_port, file_id)])
             self.validate_file(
                 os.path.join(gettempdir(), file_id),
                 os.path.join(gettempdir(), self.dest_dir, file_id, file_id))
@@ -60,8 +59,7 @@ class TestParcelHTTP(unittest.TestCase):
                 ['parcel', '-v',
                  '-n4',
                  '-d', self.dest_dir,
-                 '-s', 'http://{}:{}'.format(server_host, server_port),
-                 file_id])
+                 'http://{}:{}/{}'.format(server_host, server_port, file_id)])
             self.validate_file(
                 os.path.join(gettempdir(), file_id),
                 os.path.join(gettempdir(), self.dest_dir, file_id, file_id))

--- a/test/test_udt.py
+++ b/test/test_udt.py
@@ -48,8 +48,7 @@ class TestParcelUDT(unittest.TestCase):
                 ['parcel', 'udt', '-v',
                  '-n1',
                  '-d', self.dest_dir,
-                 'http://{}:{}'.format(server_host, server_port),
-                 file_id])
+                 'http://{}:{}/{}'.format(server_host, server_port, file_id)])
             self.validate_file(
                 os.path.join(gettempdir(), file_id),
                 os.path.join(gettempdir(), self.dest_dir, '{}_{}'.format(
@@ -63,8 +62,7 @@ class TestParcelUDT(unittest.TestCase):
                 ['parcel', 'udt', '-v',
                  '-n4',
                  '-d', self.dest_dir,
-                 'http://{}:{}'.format(server_host, server_port),
-                 file_id])
+                 'http://{}:{}/{}'.format(server_host, server_port, file_id)])
             self.validate_file(
                 os.path.join(gettempdir(), file_id),
                 os.path.join(gettempdir(), self.dest_dir, '{}_{}'.format(


### PR DESCRIPTION
Changed parcel to use URLs instead of fileIDs. This means parcel is now
more of a general tool rather than an extension of the gdc-client.

Added a segment to take care of downloads that don't have a
Content-Length in the header. This means that parallel chunked downloads
are not possible, but we can still download the files.