### PR TITLE
DTT-99: Strip quotes and split on '/' for attachment filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+*.eggs
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -46,6 +47,7 @@ htmlcov/
 .tox/
 .coverage
 .cache
+.pytest_cache/
 nosetests.xml
 coverage.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ before_install:
   - sudo apt-get install python-dev
 install:
   - python setup.py install
+  - pip install -r dev-requirements.txt
 script: "nosetests -v"

--- a/bin/parcel
+++ b/bin/parcel
@@ -17,6 +17,7 @@ log = logging.getLogger('parcel_client')
 
 def get_client(args, token, **_kwargs):
     kwargs = dict(
+        url='https://api.gdc.cancer.gov/',
         token=token,
         n_procs=args.n_processes,
         directory=args.dir,

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,9 @@
+Flask==0.10.1
+intervaltree==2.0.4
+itsdangerous==0.24
+mock==2.0.0
+parameterized==0.6.1
+progressbar==2.3
+pytest==3.4.2
+requests==2.5.1
+termcolor==1.1.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,2 @@
-Flask==0.10.1
-intervaltree==2.0.4
-itsdangerous==0.24
 mock==2.0.0
 parameterized==0.6.1
-progressbar==2.3
-pytest==3.4.2
-requests==2.5.1
-termcolor==1.1.0

--- a/test/test_parcel_download_stream.py
+++ b/test/test_parcel_download_stream.py
@@ -1,0 +1,87 @@
+import os
+import random
+import string
+import unittest
+
+from mock import Mock
+from parameterized import parameterized
+
+from parcel.download_stream import DownloadStream
+
+
+def random_string(length=10):
+    return ''.join(
+        random.choice(string.ascii_lowercase + string.ascii_uppercase)
+        for _ in range(length))
+
+
+def random_path(depth=2, name_length=10):
+    return '/{}'.format('/'.join(random_string(name_length)
+                        for _ in range(depth)))
+
+
+CONTENT_DISPOSITION = 'attachment; filename={}'
+
+
+class TestDownloadStreamGetInformation(unittest.TestCase):
+    @parameterized.expand([
+        ('Regular Name', random_string()),
+        ('Path Name', random_path(depth=4)),
+        ('Quotes in Filename', '"{}"'.format(random_string())),
+        ('Quotes in Filename', "'{}'".format(random_string())),
+        ('Quotes in Filename', '"{}"'.format(random_path())),
+        ('Quotes in Filename', "'{}'".format(random_path()))
+    ])
+    def test_get_information_filename(self, _, file_path):
+        ds = DownloadStream('http://example.com/something', 'some-directory',
+                            'some-token')
+        ds.request = Mock()
+        r = Mock()
+        disposition = CONTENT_DISPOSITION.format(file_path)
+        r.headers = {
+            'content-disposition': disposition,
+        }
+        ds.request.return_value = r
+
+        # Actual call
+        name, size = ds.get_information()
+
+        # Assertions
+        filename = os.path.basename(file_path.strip('"').strip("'"))
+        self.assertEqual(ds.name, filename)
+        self.assertEqual(ds.size, None)
+        self.assertEqual(name, filename)
+        self.assertEqual(size, None)
+
+    @parameterized.expand([
+        ('No Content-Length',
+         {},
+         {'size': None, 'md5sum': None, 'check_sum': False}),
+        ('No md5sum',
+         {'Content-Length': 1234},
+         {'size': 1234, 'md5sum': '', 'check_sum': True}),
+        ('Content-Length and md5sum',
+         {'Content-Length': 1234, 'content-md5': 'abcd'},
+         {'size': 1234, 'md5sum': 'abcd', 'check_sum': True}),
+    ])
+    def test_get_information_size_and_md5(self, _, headers, assertions):
+        ds = DownloadStream('http://exmple.com/something', 'some-directory',
+                            'some-token')
+
+        ds.request = Mock()
+        r = Mock()
+        filename = random_string()
+        disposition = CONTENT_DISPOSITION.format(filename)
+        r.headers = headers
+        r.headers['content-disposition'] = disposition
+        ds.request.return_value = r
+
+        # Actual call
+        name, size = ds.get_information()
+
+        # Assertions
+        self.assertEqual(name, filename)
+        self.assertEqual(ds.size, assertions.get('size'))
+        self.assertEqual(size, assertions.get('size'))
+        self.assertEqual(ds.check_file_md5sum, assertions.get('check_sum'))
+        self.assertEqual(ds.md5sum, assertions.get('md5sum'))


### PR DESCRIPTION
Add unittests for 'get_information'.

Add dev-requirements.txt